### PR TITLE
fix: hide module warning message on dev

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -18,7 +18,7 @@ export default defineNuxtModule<SingleHtmlOptions>({
 
     // only run when nuxi generate
     const isPrerender = nuxt.options.nitro.static
-    if (!isPrerender) {
+    if (!isPrerender && !nuxt.options.dev) {
       console.warn('nuxt-single-html module only works with `nuxt generate` or `nuxt build --prerender` commands.')
       return
     }


### PR DESCRIPTION
Currently the module writes a warning to the console about only working on generation even when running a dev server. This PR adds a check for `nuxt.options.dev` to hide that message.